### PR TITLE
Support ability to pass in a custom formatLogItem function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ winston.add(CloudWatchTransport, {
     accessKeyId: '...',
     secretAccessKey: '...',
     region: '...'
-  }
+  },
+  formatLogItem: function(item) {} // Optional custom format function
 })
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,9 @@ import LogItem from './lib/log-item'
 import Relay from './lib/relay'
 
 class CloudWatchTransport extends Transport {
-  constructor ({logGroupName, logStreamName, awsConfig}) {
+  constructor ({logGroupName, logStreamName, awsConfig, formatLogItem}) {
     super()
-    const client = new CloudWatchClient(logGroupName, logStreamName, {awsConfig})
+    const client = new CloudWatchClient(logGroupName, logStreamName, {awsConfig, formatLogItem})
     const relay = new Relay(client)
     relay.on('error', err => console.error('CloudWatch error: %s', err))
     this._queue = relay.start()

--- a/src/lib/cloudwatch-client.js
+++ b/src/lib/cloudwatch-client.js
@@ -16,7 +16,8 @@ export default class CloudWatchClient {
     this._logStreamName = logStreamName
     this._options = defaults(options, {
       awsConfig: null,
-      maxSequenceTokenAge: -1
+      maxSequenceTokenAge: -1,
+      formatLogItem: CloudWatchEventFormatter.formatLogItem
     })
     this._sequenceTokenInfo = null
     const client = new AWS.CloudWatchLogs(this._options.awsConfig)
@@ -35,7 +36,7 @@ export default class CloudWatchClient {
     const params = {
       logGroupName: this._logGroupName,
       logStreamName: this._logStreamName,
-      logEvents: batch.map(CloudWatchEventFormatter.formatLogItem),
+      logEvents: batch.map(this._options.formatLogItem),
       sequenceToken
     }
     return this._client.putLogEventsAsync(params)

--- a/test/unit/test-cloudwatch-client.js
+++ b/test/unit/test-cloudwatch-client.js
@@ -107,7 +107,10 @@ describe('CloudWatchClient', () => {
 
     it('logs with custom formatLogItem option', () => {
       const formatLogItem = sinon.spy((item) => {
-        return `CUSTOM__${JSON.stringify(item)}`
+        return {
+          timestamp: item.date,
+          message: `CUSTOM__${JSON.stringify(item)}`
+        }
       })
 
       const client = createClient({formatLogItem})

--- a/test/unit/test-cloudwatch-client.js
+++ b/test/unit/test-cloudwatch-client.js
@@ -104,5 +104,18 @@ describe('CloudWatchClient', () => {
             .then(() => client._client.describeLogStreamsAsync.calledOnce)
         ).to.eventually.equal(true)
     })
+
+    it('logs with custom formatLogItem option', () => {
+      const formatLogItem = sinon.spy((item) => {
+        return `CUSTOM__${JSON.stringify(item)}`
+      })
+
+      const client = createClient({formatLogItem})
+      const batch = createBatch(1)
+      return expect(
+          client.submit(batch)
+            .then(() => formatLogItem.calledOnce)
+        ).to.eventually.equal(true)
+    })
   })
 })


### PR DESCRIPTION
Adds an additional `formatLogItem` property to `CloudWatchTransport` constructor. If no value is specified it defaults to `CloudWatchEventFormatter.formatLogItem`.
