### PR TITLE
formatLogItem should return an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ winston.add(CloudWatchTransport, {
     region: '...'
   },
   formatLogItem: function (item) {
-    return item.level + ': ' + item.message + ' ' + JSON.stringify(item.meta)
+    return {
+      message: item.level + ': ' + item.message + ' ' + JSON.stringify(item.meta),
+      timestamp: item.date
+    }
   }
 })
 ```


### PR DESCRIPTION
in README.md it says that you can pass a function to formatLogItem that returns a string, but that doesn't work. The formatLogItem expects a function that returns an object with a message and timestamp. If only a string is returned it throws an error and no logs are sent to AWS CloudWatch. 

I found this fix in `cloudwatch-event-formatter.js:32` in which the formatLogItem function is returning an object that has a `message` and `timestamp`. It took me a while to find this  though because the documentation in README.md says that you only need to return a string.
